### PR TITLE
Add EPPlus example to count Current rows

### DIFF
--- a/ExcelReadTest/ExcelReadTest.csproj
+++ b/ExcelReadTest/ExcelReadTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EPPlus" Version="8.0.8" />
+    <PackageReference Include="EPPlus" Version="7.3.0" />
   </ItemGroup>
 
 </Project>

--- a/ExcelReadTest/Program.cs
+++ b/ExcelReadTest/Program.cs
@@ -1,2 +1,56 @@
-﻿// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+using System;
+using System.IO;
+using OfficeOpenXml;
+
+// Change the license context for EPPlus. This is required for non-commercial
+// use of the library.
+ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+
+var filePath = @"C:\Users\SupunRathnayake\Downloads\V1HBL_PD-WCM_Term Loan_Jul 2024_ai.xlsx";
+var sheetName = "2023-Jul";
+var columnHeader = "2023-Jul DPD Bucket";
+
+if (!File.Exists(filePath))
+{
+    Console.WriteLine($"File not found: {filePath}");
+    return;
+}
+
+using var package = new ExcelPackage(new FileInfo(filePath));
+var worksheet = package.Workbook.Worksheets[sheetName];
+if (worksheet == null)
+{
+    Console.WriteLine($"Worksheet '{sheetName}' not found.");
+    return;
+}
+
+// Determine the column index of the specified header.
+int columnIndex = -1;
+int headerRow = worksheet.Dimension.Start.Row;
+for (int col = worksheet.Dimension.Start.Column; col <= worksheet.Dimension.End.Column; col++)
+{
+    if (worksheet.Cells[headerRow, col].Text.Trim() == columnHeader)
+    {
+        columnIndex = col;
+        break;
+    }
+}
+
+if (columnIndex == -1)
+{
+    Console.WriteLine($"Column '{columnHeader}' not found.");
+    return;
+}
+
+// Iterate over rows and count how many contain the value "Current".
+int count = 0;
+for (int row = headerRow + 1; row <= worksheet.Dimension.End.Row; row++)
+{
+    var value = worksheet.Cells[row, columnIndex].Text.Trim();
+    if (string.Equals(value, "Current", StringComparison.OrdinalIgnoreCase))
+    {
+        count++;
+    }
+}
+
+Console.WriteLine($"Rows where '{columnHeader}' = 'Current': {count}");

--- a/ExcelReadTest/Program.cs
+++ b/ExcelReadTest/Program.cs
@@ -26,7 +26,8 @@ if (worksheet == null)
 
 // Determine the column index of the specified header.
 int columnIndex = -1;
-int headerRow = worksheet.Dimension.Start.Row;
+//int headerRow = worksheet.Dimension.Start.Row;
+int headerRow = 5; 
 for (int col = worksheet.Dimension.Start.Column; col <= worksheet.Dimension.End.Column; col++)
 {
     if (worksheet.Cells[headerRow, col].Text.Trim() == columnHeader)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # ExcelReadTest
+
+This sample console application demonstrates how to read data from an Excel
+file using the EPPlus library.
+
+## Running the sample
+
+1. Install the .NET 8 SDK if you don't already have it.
+2. From the repository root, run:
+
+   ```bash
+   dotnet run --project ExcelReadTest
+   ```
+
+The program reads the file located at
+`C:\Users\SupunRathnayake\Downloads\V1HBL_PD-WCM_Term Loan_Jul 2024_ai.xlsx`
+and prints the number of rows in the `2023-Jul` sheet where the
+`2023-Jul DPD Bucket` column has the value `Current`.


### PR DESCRIPTION
## Summary
- implement Program.cs using EPPlus to count rows where "2023-Jul DPD Bucket" equals `Current`
- update README with instructions

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885a793932c8327a5c7685eefb2356a